### PR TITLE
Add option to display gutters

### DIFF
--- a/examples/gutters.js
+++ b/examples/gutters.js
@@ -1,0 +1,57 @@
+/*global define*/
+
+define(['faker', 'dataset'], function (Faker, dataset) {
+	"use strict";
+
+	// Generate Grid Options
+	return [function () {
+
+		var idExtractor = function (item) {
+			return item.id;
+		};
+
+		// Generate Columns
+		var columns = [];
+		for (var q = 0; q < 3; q++) {
+			columns.push({
+				id: "id" + q,
+				dataExtractor: idExtractor,
+				name: "ID",
+				maxWidth: 150,
+				sortable: true,
+				tooltip: "ID of the item"
+			}, {
+				id: "name" + q,
+				name: "Name",
+				field: "name",
+				minWidth: 100,
+				sortable: true,
+				tooltip: "This is the name of the individual"
+			}, {
+				id: "email" + q,
+				name: "Email",
+				field: "email",
+				sortable: true,
+				tooltip: "Their email address"
+			}, {
+				id: "company" + q,
+				name: "Company",
+				field: "company",
+				sortable: true,
+				tooltip: "The user's company"
+			}, {
+				id: "random" + q,
+				name: "Random Words",
+				field: "lorem",
+				sortable: true,
+				tooltip: "Some random words"
+			});
+		}
+
+		return {
+			columns: columns,
+			data: dataset,
+			showGutters: true
+		};
+	}];
+});

--- a/examples/index.html
+++ b/examples/index.html
@@ -332,6 +332,7 @@
 			<li><a href="#rowselect">Row Selection</a></li>
 			<li><a href="#frozencolumns">Frozen Columns</a></li>
 			<li><a href="#menuextensions">Menu Extensions</a></li>
+			<li><a href="#gutters">Gutters</a></li>
 		</ul>
 
 		<div id="toolbar">

--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -62,6 +62,7 @@ var DobyGrid = function (options) {
 	// Private
 	var self = this,
 		$canvas,
+		$gutters,
 		$headers,
 		$headerL,
 		$headerR,
@@ -359,6 +360,7 @@ var DobyGrid = function (options) {
 		selectable:				true,
 		selectedClass:			"selected",
 		shiftSelect:			true,
+		showGutters:			false,
 		showHeader:				true,
 		stickyFocus:			false,
 		stickyGroupRows:		false,
@@ -1775,6 +1777,7 @@ var DobyGrid = function (options) {
 		var cclasses = [self.NAME];
 		if (self.options.class) cclasses.push(self.options.class);
 		if (self.options.scrollbarPosition === 'left') cclasses.push(CLS.left);
+		if (self.options.showGutters) cclasses.push(CLS.guttersVisible);
 
 		self.$el = $('<div class="' + cclasses.join(' ') + '" id="' + uid + '"></div>');
 
@@ -1784,6 +1787,7 @@ var DobyGrid = function (options) {
 		$panes = $();
 		$viewport = $();
 		$canvas = $();
+		$gutters = $();
 
 		for (var i = 0, l = panes.length; i < l; i++) {
 			// Generate panes
@@ -1800,6 +1804,16 @@ var DobyGrid = function (options) {
 				(self.options.frozenColumns > -1 && i % 2 === 0 ? ' ' + CLS.autoheight : ''),
 				'"></div>'
 			].join('')).appendTo($p);
+
+			// Create gutters.
+			if (self.options.showGutters) {
+				var gutter = '<div class="' + CLS.gutter + '"></div>';
+				var $gutterLeft = $(gutter).addClass('left').appendTo($v);
+				var $gutterRight = $(gutter).addClass('right').appendTo($v);
+				$gutters = $gutters
+					.add($gutterLeft)
+					.add($gutterRight);
+			}
 
 			// Generate canvas
 			// The tabindex here ensures we can focus on this element
@@ -5997,6 +6011,13 @@ var DobyGrid = function (options) {
 					scrollLeftDelta: scrollLeftDelta,
 					scrollTopDelta: scrollTopDelta
 				});
+			}
+
+			// Reposition gutters.
+			if (self.options.showGutters) {
+				$gutters.css('top', scrollTop);
+				$gutters.filter('.left').css('left', scrollLeft);
+				$gutters.filter('.right').css('right', -scrollLeft);
 			}
 		}
 

--- a/src/doby-grid.less
+++ b/src/doby-grid.less
@@ -12,7 +12,6 @@
 // Containers
 // ==================================================================================================
 
-
 .doby-grid {
 	.box-sizing(content-box);
 	font-size: 12px;
@@ -289,7 +288,6 @@
 // Body
 // ==================================================================================================
 
-
 .doby-grid-viewport {
 	height: 100%;
 	overflow: auto;
@@ -534,4 +532,42 @@
 	right: 0;
 	top: 0;
 	z-index: 1;
+}
+
+
+// Gutters
+// ==================================================================================================
+
+.doby-grid-gutters-visible {
+	.doby-grid-header-columns {
+		padding: 0 20px;
+	}
+
+	.doby-grid-canvas {
+		display: inline-block;
+		margin: 0 20px;
+	}
+}
+
+.doby-grid-gutter {
+	border-style: solid;
+	border-width: 0;
+	content: "";
+	display: block;
+	height: 100%;
+	pointer-events: none;
+	position: absolute;
+	top: 0;
+	width: 20px;
+	z-index: 100;
+
+	&.left {
+		border-right-width: 1px;
+		left: 0;
+	}
+
+	&.right {
+		border-left-width: 1px;
+		right: 0;
+	}
 }

--- a/src/themes/doby-grid-dark.less
+++ b/src/themes/doby-grid-dark.less
@@ -340,3 +340,13 @@
 	.doby-grid-message > div > div {
 		color: #E98;
 	}
+
+
+/*! Gutters
+================================================================================================== */
+
+
+.doby-grid-gutter {
+	background-color: #111;
+	border-color: #393939;
+}

--- a/src/themes/doby-grid-light.less
+++ b/src/themes/doby-grid-light.less
@@ -329,3 +329,14 @@
 	.doby-grid-message > div > div {
 		color: #E98;
 	}
+
+
+/*! Gutters
+================================================================================================== */
+
+
+.doby-grid-gutter {
+	background-color: #EAEAEA;
+	border-color: #CACACA;
+	box-shadow: 1px 1px 0 rgba(255,255,255,0.3) inset;
+}

--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -27,6 +27,8 @@ module.exports = {
 	group:					base + '-group',
 	grouptitle:				base + '-group-title',
 	grouptoggle:			base + '-group-toggle',
+	gutter:					base + '-gutter',
+	guttersVisible:			base + '-gutters-visible',
 	handle:					base + '-resizable-handle',
 	header:					base + '-header',
 	headercolumns:			base + '-header-columns',


### PR DESCRIPTION
As requested in #180, this adds an option to display a margin around the grid so that it's not flush with the scrollbar.

I tried a number of different approaches, eventually settling on additional divs that overlay the grid and adding extra margins around the header and grid body so that all content is still visible. The gutters are repositioned via JavaScript during scroll events. Whether this aesthetically the best solution is up for discussion.

I added a new example page but no test yet.