### PR TITLE
Fixed problem with undefined cell nodes

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -4265,7 +4265,8 @@ var DobyGrid = function (options) {
 			// Do not allow negative values
 			nodecell = nodecell < 0 ? 0 : nodecell;
 
-			return cache.nodes[row].cellNodesByColumnIdx[nodecell][0];
+			var cellNodeArray = cache.nodes[row].cellNodesByColumnIdx[nodecell];
+			return cellNodeArray && cache.nodes[row].cellNodesByColumnIdx[nodecell][0];
 		}
 		return null;
 	};


### PR DESCRIPTION
I ran into problems when cache.nodes[row].cellNodesByColumnIdx[nodecell] is undefined. The call to [0] will through an error. The old behaviour (before there was a call to [0]) was that getNodeCell() will return undefined in this situation.

I added a check to make sure undefined is returned again.