### PR TITLE
Update Bower link for jquery.event.drag-drop

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,7 @@
     "FileSaver": "",
     "jquery": "2.1.1",
     "jquery-ui": "1.11.0",
-    "jquery.event.drag-drop": "2.2.1",
+    "jquery.event.drag-drop": "https://github.com/threedubmedia/jquery.threedubmedia.git#2.2",
     "underscore": "1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The repository it was pointing to has disappeared, meaning that running `bower install` fails. Replacing it with [this repo](https://github.com/threedubmedia/jquery.threedubmedia) hosted by threedubmedia (the original author of the library) fixes this.

An alternative is to mirror the library ourselves and point the Bower link to it instead (which appears to be the purpose of [this mirror](https://github.com/tomkasp/jquery.event.drag-drop)). I doubt there's a high chance of the original code repository disappearing though.