### PR TITLE
Further jquery node fixes. Remove method cleans up listeners too.

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -1437,7 +1437,7 @@ var DobyGrid = function (options) {
 			cacheEntry = cache.nodes[processedRow];
 			while ((columnIdx = cacheEntry.cellRenderQueue.pop()) !== null && columnIdx !== undefined) {
 				node = x.lastChild;
-				cacheEntry.rowNode[0].appendChild(node);
+				cacheEntry.rowNode.append(node);
 				cacheEntry.cellNodesByColumnIdx[columnIdx] = node;
 			}
 		}
@@ -1480,7 +1480,7 @@ var DobyGrid = function (options) {
 
 		var cellToRemove;
 		while (((cellToRemove = cellsToRemove.pop()) !== null && cellToRemove !== undefined) && cellToRemove) {
-			cacheEntry.rowNode[0].removeChild(cacheEntry.cellNodesByColumnIdx[cellToRemove][0]);
+			cacheEntry.cellNodesByColumnIdx[cellToRemove].remove();
 			delete cacheEntry.cellColSpans[cellToRemove];
 			delete cacheEntry.cellNodesByColumnIdx[cellToRemove];
 			if (cache.postprocess[cache.rows[row].id]) {


### PR DESCRIPTION
I had a problem with the calls to append newly rendered content to cells that hadn't rendered into the cache. I fixed it by changing the call to use jQuery calls rather than DOM methods.
I think the benefits of this over the one in #194 are:
* It is more consistent with the rest of the code that tends to use jQuery methods
* The jQuery remove method also removes and cleans up event listeners, which the DOM method does not.

Please note, I find the unit tests fail on my Ubuntu laptop, but it is on the estimate of how wide the fonts are, so I hope on your build systems they will work. All other tests pass.
 ```
   options.minColumnWidth
     - should be enabled empty by default......✓
     - should resize columns to match the header content width when using 'headerContent'......X
       Expected 244 to be greater than 247. (1)
       Expected 223 to be greater than 247. (2)
     - should be able to toggle the 'minColumnWidth' property using 'setOptions'......X
       Expected 244 to be greater than 247. (1)
       Expected 223 to be greater than 247. (2)
```
