### PR TITLE
Cache newly rendered cells on horizontal scrolling as jQuery objects.

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -1436,7 +1436,7 @@ var DobyGrid = function (options) {
 		while ((processedRow = processedRows.pop()) !== null && processedRow !== undefined) {
 			cacheEntry = cache.nodes[processedRow];
 			while ((columnIdx = cacheEntry.cellRenderQueue.pop()) !== null && columnIdx !== undefined) {
-				node = x.lastChild;
+				node = $(x.lastChild);
 				cacheEntry.rowNode.append(node);
 				cacheEntry.cellNodesByColumnIdx[columnIdx] = node;
 			}


### PR DESCRIPTION
* These were being added as DOM nodes and causing errors on cell selection.
* The issue occurred with 40+ columns on my 1920 width screen.